### PR TITLE
Add live color contrast analysis dashboard

### DIFF
--- a/packages/site/index.html
+++ b/packages/site/index.html
@@ -73,6 +73,44 @@
         </div>
       </div>
 
+      <!-- Contrast dashboard -->
+      <div class="max-w-7xl mx-auto mt-16 pt-12 border-t border-white/5">
+        <h2 class="text-sm font-semibold uppercase tracking-widest text-stilla-comment mb-2">Contrast Analysis</h2>
+        <p class="text-sm text-stilla-steel mb-8">
+          Measured against
+          <a href="https://www.w3.org/TR/WCAG21/#contrast-minimum" class="underline underline-offset-2 hover:text-stilla-cyan transition-colors">WCAG 2.1</a>
+          contrast ratio and the
+          <a href="https://readtech.org/ARC/" class="underline underline-offset-2 hover:text-stilla-cyan transition-colors">APCA</a>
+          (WCAG 3.0 draft) lightness-contrast algorithm. Updates live as you adjust colors above.
+        </p>
+
+        <!-- Summary cards -->
+        <div id="contrast-summary" class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8"></div>
+
+        <!-- Pairing table -->
+        <div class="overflow-x-auto rounded-lg border border-white/5">
+          <table class="contrast-table w-full text-sm">
+            <thead>
+              <tr class="text-left text-stilla-comment text-xs uppercase tracking-wider">
+                <th class="px-3 py-2">Pairing</th>
+                <th class="px-3 py-2">Preview</th>
+                <th class="px-3 py-2 text-right">WCAG Ratio</th>
+                <th class="px-3 py-2 text-center">WCAG Level</th>
+                <th class="px-3 py-2 text-right">APCA Lc</th>
+                <th class="px-3 py-2 text-center">APCA Rating</th>
+              </tr>
+            </thead>
+            <tbody id="contrast-tbody"></tbody>
+          </table>
+        </div>
+
+        <!-- Legend -->
+        <div class="mt-4 flex flex-wrap gap-x-6 gap-y-1 text-xs text-stilla-comment">
+          <span><strong class="text-stilla-fg">WCAG 2.1</strong> — AAA ≥ 7:1 · AA ≥ 4.5:1 · AA-large ≥ 3:1</span>
+          <span><strong class="text-stilla-fg">APCA</strong> — Best ≥ 90 · Good ≥ 75 · OK ≥ 60 · Min ≥ 30</span>
+        </div>
+      </div>
+
       <!-- Install instructions -->
       <div class="max-w-7xl mx-auto mt-16 pt-12 border-t border-white/5">
         <h2 class="text-sm font-semibold uppercase tracking-widest text-stilla-comment mb-8">Install</h2>

--- a/packages/site/src/contrast.ts
+++ b/packages/site/src/contrast.ts
@@ -1,0 +1,230 @@
+/**
+ * Color contrast analysis utilities.
+ *
+ * Implements two academic standards:
+ *   1. WCAG 2.1 relative luminance & contrast ratio (W3C Recommendation)
+ *      https://www.w3.org/TR/WCAG21/#dfn-contrast-ratio
+ *   2. APCA (Accessible Perceptual Contrast Algorithm) from WCAG 3.0 draft
+ *      https://github.com/Myndex/SAPC-APCA
+ */
+
+// ---------------------------------------------------------------------------
+// Hex parsing
+// ---------------------------------------------------------------------------
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace("#", "");
+  return [
+    parseInt(h.substring(0, 2), 16),
+    parseInt(h.substring(2, 4), 16),
+    parseInt(h.substring(4, 6), 16),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// WCAG 2.1 — Relative luminance & contrast ratio
+// ---------------------------------------------------------------------------
+
+/** sRGB channel → linear (IEC 61966-2-1) */
+function srgbToLinear(c: number): number {
+  const s = c / 255;
+  return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+}
+
+/** Relative luminance per WCAG 2.1 §1.4.3 */
+export function relativeLuminance(hex: string): number {
+  const [r, g, b] = hexToRgb(hex);
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
+}
+
+/** WCAG 2.1 contrast ratio (1:1 – 21:1) */
+export function wcagContrast(fg: string, bg: string): number {
+  const l1 = relativeLuminance(fg);
+  const l2 = relativeLuminance(bg);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+export type WcagLevel = "AAA" | "AA" | "AA-large" | "Fail";
+
+/** Evaluate WCAG 2.1 conformance level for a contrast ratio. */
+export function wcagLevel(ratio: number): WcagLevel {
+  if (ratio >= 7) return "AAA";
+  if (ratio >= 4.5) return "AA";
+  if (ratio >= 3) return "AA-large";
+  return "Fail";
+}
+
+// ---------------------------------------------------------------------------
+// APCA (WCAG 3.0 draft) — Lc value
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt a simplified APCA calculation (SAPC-APCA 0.1.9 reference).
+ * Returns lightness-contrast value Lc (roughly -108 to +106).
+ * Positive = light text on dark, negative = dark text on light.
+ *
+ * Thresholds (absolute |Lc|):
+ *   ≥ 90  body text (fluent reading)
+ *   ≥ 75  content text
+ *   ≥ 60  large/bold text
+ *   ≥ 45  non-text, large UI elements
+ *   ≥ 30  minimum for any purpose
+ *   < 30  invisible / not usable
+ */
+export function apcaLc(textHex: string, bgHex: string): number {
+  const [tr, tg, tb] = hexToRgb(textHex);
+  const [br, bg_, bb] = hexToRgb(bgHex);
+
+  // Linearize with sRGB companding coefficients per APCA spec
+  const mainTRC = 2.4;
+  const lin = (v: number) => (v / 255) ** mainTRC;
+
+  const txtY = 0.2126729 * lin(tr) + 0.7151522 * lin(tg) + 0.0721750 * lin(tb);
+  const bgY = 0.2126729 * lin(br) + 0.7151522 * lin(bg_) + 0.0721750 * lin(bb);
+
+  // Soft clamp
+  const txtYc = txtY > 0.022 ? txtY : txtY + (0.022 - txtY) ** 1.414;
+  const bgYc = bgY > 0.022 ? bgY : bgY + (0.022 - bgY) ** 1.414;
+
+  // SAPC — polarity-aware exponent
+  const normBG = 0.56;
+  const normTXT = 0.57;
+  const revBG = 0.65;
+  const revTXT = 0.62;
+  const scaleBoW = 1.14;
+  const scaleWoB = 1.14;
+  const loBoWoffset = 0.027;
+  const loWoBoffset = 0.027;
+  const loClip = 0.1;
+
+  let SAPC: number;
+  if (bgYc > txtYc) {
+    // Dark text on light background
+    SAPC = (bgYc ** normBG - txtYc ** normTXT) * scaleBoW;
+    return Math.abs(SAPC) < loClip ? 0 : SAPC > 0 ? SAPC - loBoWoffset : 0;
+  }
+  // Light text on dark background
+  SAPC = (bgYc ** revBG - txtYc ** revTXT) * scaleWoB;
+  return Math.abs(SAPC) < loClip ? 0 : SAPC < 0 ? SAPC + loWoBoffset : 0;
+}
+
+export type ApcaRating = "Best" | "Good" | "OK" | "Min" | "Fail";
+
+export function apcaRating(lc: number): ApcaRating {
+  const abs = Math.abs(lc);
+  if (abs >= 90) return "Best";
+  if (abs >= 75) return "Good";
+  if (abs >= 60) return "OK";
+  if (abs >= 30) return "Min";
+  return "Fail";
+}
+
+// ---------------------------------------------------------------------------
+// Theme-specific pairing analysis
+// ---------------------------------------------------------------------------
+
+export interface ContrastPairing {
+  name: string;
+  fgKey: string;
+  bgKey: string;
+  fg: string;
+  bg: string;
+  wcagRatio: number;
+  wcagGrade: WcagLevel;
+  apca: number;
+  apcaGrade: ApcaRating;
+}
+
+export interface PaletteStats {
+  pairings: ContrastPairing[];
+  wcagAAA: number;
+  wcagAA: number;
+  wcagAALarge: number;
+  wcagFail: number;
+  avgWcag: number;
+  avgApca: number;
+  minWcag: ContrastPairing;
+  maxWcag: ContrastPairing;
+}
+
+type Palette = Record<string, string>;
+
+/** Pairs that actually appear in the Stilla theme (syntax + UI). */
+const THEME_PAIRINGS: Array<{ name: string; fgKey: string; bgKey: string }> = [
+  // Syntax tokens against editor background
+  { name: "Foreground / bg", fgKey: "fg", bgKey: "bg" },
+  { name: "Comment / bg", fgKey: "comment", bgKey: "bg" },
+  { name: "Keyword (steel) / bg", fgKey: "steel", bgKey: "bg" },
+  { name: "String (sage) / bg", fgKey: "sage", bgKey: "bg" },
+  { name: "Type (teal) / bg", fgKey: "teal", bgKey: "bg" },
+  { name: "Number (magenta) / bg", fgKey: "magenta", bgKey: "bg" },
+  { name: "Escape (yellow) / bg", fgKey: "yellow", bgKey: "bg" },
+  { name: "Metatag (navy) / bg", fgKey: "navy", bgKey: "bg" },
+  { name: "Delimiter (warmWhite) / bg", fgKey: "warmWhite", bgKey: "bg" },
+  { name: "Orange / bg", fgKey: "orange", bgKey: "bg" },
+  { name: "Red / bg", fgKey: "red", bgKey: "bg" },
+  { name: "Cyan / bg", fgKey: "cyan", bgKey: "bg" },
+
+  // UI chrome
+  { name: "Line number (muted) / bg", fgKey: "muted", bgKey: "bg" },
+  { name: "Foreground / bgAlt", fgKey: "fg", bgKey: "bgAlt" },
+  { name: "Comment / bgAlt", fgKey: "comment", bgKey: "bgAlt" },
+  { name: "Muted / surface", fgKey: "muted", bgKey: "surface" },
+  { name: "Steel / bgAlt", fgKey: "steel", bgKey: "bgAlt" },
+  { name: "Foreground / surface", fgKey: "fg", bgKey: "surface" },
+
+  // Site-level
+  { name: "fgAlt / bgAlt", fgKey: "fgAlt", bgKey: "bgAlt" },
+  { name: "Deep teal / bg", fgKey: "deepTeal", bgKey: "bg" },
+  { name: "Dark blue / bg", fgKey: "darkBlue", bgKey: "bg" },
+  { name: "Khaki / bg", fgKey: "khaki", bgKey: "bg" },
+];
+
+export function analyzePalette(p: Palette): PaletteStats {
+  const pairings: ContrastPairing[] = [];
+
+  for (const { name, fgKey, bgKey } of THEME_PAIRINGS) {
+    const fg = p[fgKey];
+    const bg = p[bgKey];
+    if (!fg || !bg) continue;
+
+    const ratio = wcagContrast(fg, bg);
+    const lc = apcaLc(fg, bg);
+
+    pairings.push({
+      name,
+      fgKey,
+      bgKey,
+      fg,
+      bg,
+      wcagRatio: ratio,
+      wcagGrade: wcagLevel(ratio),
+      apca: lc,
+      apcaGrade: apcaRating(lc),
+    });
+  }
+
+  const sorted = [...pairings].sort((a, b) => a.wcagRatio - b.wcagRatio);
+  const counts = { AAA: 0, AA: 0, "AA-large": 0, Fail: 0 };
+  let totalWcag = 0;
+  let totalApca = 0;
+  for (const p of pairings) {
+    counts[p.wcagGrade]++;
+    totalWcag += p.wcagRatio;
+    totalApca += Math.abs(p.apca);
+  }
+
+  return {
+    pairings,
+    wcagAAA: counts.AAA,
+    wcagAA: counts.AA,
+    wcagAALarge: counts["AA-large"],
+    wcagFail: counts.Fail,
+    avgWcag: totalWcag / pairings.length,
+    avgApca: totalApca / pairings.length,
+    minWcag: sorted[0],
+    maxWcag: sorted[sorted.length - 1],
+  };
+}

--- a/packages/site/src/main.ts
+++ b/packages/site/src/main.ts
@@ -2,6 +2,7 @@ import * as monaco from "monaco-editor";
 import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
 import { palette as defaultPalette, type PaletteKey } from "stilla-colors";
+import { analyzePalette, type PaletteStats, type WcagLevel, type ApcaRating } from "./contrast";
 
 // Monaco worker setup for Vite
 self.MonacoEnvironment = {
@@ -143,10 +144,86 @@ function updateChromeColors(p: Palette) {
   root.style.setProperty("--chrome-cyan", p.cyan);
 }
 
+// ---------------------------------------------------------------------------
+// Contrast dashboard
+// ---------------------------------------------------------------------------
+
+const WCAG_COLORS: Record<WcagLevel, string> = {
+  AAA: "#28c840",
+  AA: "#88B6D0",
+  "AA-large": "#E9B872",
+  Fail: "#BA8082",
+};
+
+const APCA_COLORS: Record<ApcaRating, string> = {
+  Best: "#28c840",
+  Good: "#88B6D0",
+  OK: "#E9B872",
+  Min: "#D99962",
+  Fail: "#BA8082",
+};
+
+function renderSummary(stats: PaletteStats) {
+  const el = document.getElementById("contrast-summary");
+  if (!el) return;
+
+  const cards: Array<{ label: string; value: string; sub: string }> = [
+    { label: "Avg WCAG Ratio", value: `${stats.avgWcag.toFixed(1)}:1`, sub: `Best ${stats.maxWcag.wcagRatio.toFixed(1)}:1 · Worst ${stats.minWcag.wcagRatio.toFixed(1)}:1` },
+    { label: "Avg APCA |Lc|", value: Math.round(stats.avgApca).toString(), sub: `${stats.pairings.length} pairings analyzed` },
+    { label: "WCAG AA+ Pass", value: `${stats.wcagAAA + stats.wcagAA}/${stats.pairings.length}`, sub: `AAA: ${stats.wcagAAA} · AA: ${stats.wcagAA}` },
+    { label: "Needs Work", value: `${stats.wcagFail + stats.wcagAALarge}`, sub: `AA-large: ${stats.wcagAALarge} · Fail: ${stats.wcagFail}` },
+  ];
+
+  el.innerHTML = cards
+    .map(
+      (c) => `
+    <div class="bg-stilla-bg rounded-lg px-4 py-3">
+      <div class="text-xs uppercase tracking-wider text-stilla-comment mb-1">${c.label}</div>
+      <div class="text-2xl font-semibold text-stilla-fg">${c.value}</div>
+      <div class="text-xs text-stilla-muted mt-1">${c.sub}</div>
+    </div>`,
+    )
+    .join("");
+}
+
+function badgeHtml(text: string, color: string): string {
+  return `<span class="contrast-badge" style="--badge-color:${color}">${text}</span>`;
+}
+
+function renderTable(stats: PaletteStats) {
+  const tbody = document.getElementById("contrast-tbody");
+  if (!tbody) return;
+
+  tbody.innerHTML = stats.pairings
+    .map(
+      (p) => `
+    <tr class="border-t border-white/5">
+      <td class="px-3 py-2 whitespace-nowrap">
+        <span class="text-stilla-fg">${p.name}</span>
+      </td>
+      <td class="px-3 py-2">
+        <span class="contrast-preview" style="color:${p.fg};background:${p.bg}">Aa</span>
+      </td>
+      <td class="px-3 py-2 text-right font-mono">${p.wcagRatio.toFixed(2)}</td>
+      <td class="px-3 py-2 text-center">${badgeHtml(p.wcagGrade, WCAG_COLORS[p.wcagGrade])}</td>
+      <td class="px-3 py-2 text-right font-mono">${p.apca.toFixed(1)}</td>
+      <td class="px-3 py-2 text-center">${badgeHtml(p.apcaGrade, APCA_COLORS[p.apcaGrade])}</td>
+    </tr>`,
+    )
+    .join("");
+}
+
+function updateDashboard() {
+  const stats = analyzePalette(currentPalette);
+  renderSummary(stats);
+  renderTable(stats);
+}
+
 function applyTheme() {
   monaco.editor.defineTheme("stilla", buildMonacoTheme(currentPalette));
   monaco.editor.setTheme("stilla");
   updateChromeColors(currentPalette);
+  updateDashboard();
 }
 
 function init() {
@@ -252,6 +329,7 @@ function init() {
   });
 
   updateChromeColors(currentPalette);
+  updateDashboard();
 }
 
 init();

--- a/packages/site/src/style.css
+++ b/packages/site/src/style.css
@@ -93,3 +93,36 @@
   color: var(--color-stilla-comment);
   font-size: 0.6875rem;
 }
+
+/* Contrast dashboard */
+.contrast-table {
+  border-collapse: collapse;
+}
+
+.contrast-table thead {
+  background: var(--color-stilla-bg);
+}
+
+.contrast-table tbody tr:hover {
+  background: var(--color-stilla-bg);
+}
+
+.contrast-preview {
+  display: inline-block;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-weight: 600;
+  font-size: 0.8125rem;
+  line-height: 1.25;
+}
+
+.contrast-badge {
+  display: inline-block;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 9999px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--badge-color);
+  background: color-mix(in srgb, var(--badge-color) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--badge-color) 25%, transparent);
+}


### PR DESCRIPTION
Introduces a reactive contrast dashboard to the showcase site that
measures every theme color pairing against two academic standards:

- WCAG 2.1 contrast ratio (W3C Recommendation) with AA/AAA grading
- APCA lightness-contrast (WCAG 3.0 draft) with Best/Good/OK/Min ratings

The dashboard includes summary cards (averages, pass counts, worst-case)
and a full pairing table with live preview swatches. All metrics update
in real-time as the user adjusts colors via the existing color pickers.

https://claude.ai/code/session_01SWtNnH18hMgoiGDYbRsdym